### PR TITLE
qemu_template: use more cpus for ARM if available

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -158,7 +158,12 @@ else
         arm64-usr+aarch64)
             set -- -machine virt,accel=kvm,gic-version=3 -cpu host -smp "${VM_NCPUS}" -nographic "$@" ;;
         arm64-usr+*)
-            set -- -machine virt -cpu cortex-a57 -smp 1 -nographic "$@" ;;
+            if test "${VM_NCPUS}" -gt 4 ; then
+                VM_NCPUS=4
+            elif test "${VM_NCPUS}" -gt 2 ; then
+                VM_NCPUS=2
+            fi
+            set -- -machine virt -cpu cortex-a57 -smp "${VM_NCPUS}" -nographic "$@" ;;
         *)
             die "Unsupported arch" ;;
     esac


### PR DESCRIPTION
# qemu_template: use more cpus for ARM if available

add some logic to provide more CPUs (than hardcoded '1') for ARM.
But don't hog all `VM_NCPUS`, as we are still emulating them

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

# How to use

This script will end up in the release artifacts, so I tested this diff running the most recent arm build (2605.1.0)


# Testing done
```shell
core@flatcar-local ~ $ cat /etc/os-release 
NAME="Flatcar Container Linux by Kinvolk"
ID=flatcar
ID_LIKE=coreos
VERSION=2605.1.0
VERSION_ID=2605.1.0
BUILD_ID=2020-08-31-1924
PRETTY_NAME="Flatcar Container Linux by Kinvolk 2605.1.0 (Oklo)"
ANSI_COLOR="38;5;75"
HOME_URL="https://flatcar-linux.org/"
BUG_REPORT_URL="https://issues.flatcar-linux.org"
FLATCAR_BOARD="arm64-usr"
core@flatcar-local ~ $ lscpu
Architecture:        aarch64
Byte Order:          Little Endian
CPU(s):              4
On-line CPU(s) list: 0-3
Thread(s) per core:  1
Core(s) per socket:  4
Socket(s):           1
NUMA node(s):        1
Vendor ID:           ARM
Model:               0
Model name:          Cortex-A57
Stepping:            r1p0
BogoMIPS:            125.00
NUMA node0 CPU(s):   0-3
Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
```