### PR TITLE
jenkins: Generate and upload update payloads too

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -94,7 +94,7 @@ generate_update() {
       -new_kernel "${image_kernel}" \
       -out_file "${update}.gz"
 
-  upload_image -d "${update}.DIGESTS" "${update}".{bin,gz,zip}
+  upload_image -d "${update}.DIGESTS" "${update}".{bin,gz}
 }
 
 # ldconfig cannot generate caches for non-native arches.

--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -67,6 +67,7 @@ done < <(jq -r '.value.packages[] | . as $p | .name as $n | $p.versions[] | [.ca
 script build_image \
     --board="${BOARD}" \
     --group="${GROUP}" \
+    --generate_update \
     --getbinpkg \
     --getbinpkgver="${FLATCAR_VERSION}" \
     --sign="${SIGNING_USER}" \


### PR DESCRIPTION
This may come handy for testing the updates. This change should be
enough, since the `generate_update` function also uploads the
generated payloads if the `--upload` flag was passed. Which this
script is doing.

# How to use

Nothing else is needed to do, just run the build. The uploading of the update payload should happen as a part of the image matrix part.

# Testing done

Not finished yet: http://localhost:9091/job/os/job/manifest/1137/