### PR TITLE
build_library: Ignore broken symlink in Kernel source tree

### DIFF
--- a/build_library/check_root
+++ b/build_library/check_root
@@ -128,7 +128,8 @@ IGNORE_SYMLINK = (
     # Other
     b"/etc/lsb-release",  # set later in the build process
     b"/usr/share/coreos", # set later in the build process
-    b"/etc/coreos"        # set later in the build process
+    b"/etc/coreos",       # set later in the build process
+    b"/usr/src/linux-*/tools/testing/selftests/powerpc/copyloops/memcpy_mcsafe_64.S" # broken symlink in Kernel source tree
 )
 
 


### PR DESCRIPTION
Kernel source tree started to have a broken link `tools/testing/selftests/powerpc/copyloops/memcpy_mcsafe_64.S`.
Especially in case of Kernel 5.8.18, like:

```
broken link: /usr/src/linux-5.8.18-coreos/tools/testing/selftests/powerpc/copyloops/memcpy_mcsafe_64.S
ERROR   build_packages: test_image_content: Failed symlink check
```

Ignore the symlink when checking broken symlinks.

## How to use

```
./build_packages
```

## Testing done

Local builds with https://github.com/kinvolk/coreos-overlay/pull/667.

