### PR TITLE
build_packages, build_image_util.sh: fix up liblto symlink

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -153,6 +153,8 @@ emerge_to_image() {
   # Make sure profile.env has been generated
   sudo -E ROOT="${root_fs_dir}" env-update --no-ldconfig
 
+  fixup_liblto_softlinks "$root_fs_dir"
+
   # TODO(marineam): just call ${BUILD_LIBRARY_DIR}/check_root directly once
   # all tests are fatal, for now let the old function skip soname errors.
   ROOT="${root_fs_dir}" PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \

--- a/build_packages
+++ b/build_packages
@@ -252,6 +252,8 @@ fi
 
 eclean-$BOARD -d packages
 
+fixup_liblto_softlinks "${BOARD_ROOT}"
+
 info "Checking build root"
 test_image_content "${BOARD_ROOT}"
 


### PR DESCRIPTION
This change fixes an issue with builds that use a gcc-9.3.0 SDK. `gcc-config` in that SDK version creates a symlink in binutils' libs directory to gcc's `liblto` since some packages expect binutils to ship that library. The wrong symlink is created for chroot environments however, which makes a health check fail in the `build_packages` and `build_image` script. We fix this by correcting the symlink with a new custom function in `common.sh`.

This change is required in order to build the packages and image with the gcc-9.3.0 SDK.