### PR TITLE
Update the azure pro package reference to the oem-azure-pro

### DIFF
--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -2,6 +2,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+get_binhost_url() {
+	if [ "${DEFAULT_GROUP}" == "developer" ]; then
+		echo "https://storage.googleapis.com/flatcar-jenkins/${DEFAULT_GROUP}/boards/${BOARD}/${FLATCAR_VERSION}/$1"
+	else
+		echo "https://storage.googleapis.com/flatcar-jenkins/boards/${BOARD}/${FLATCAR_VERSION_ID}/$1"
+	fi
+}
+
 configure_dev_portage() {
     # Need profiles at the bare minimum
     local repo
@@ -25,8 +33,8 @@ PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"
 PORTDIR="/var/lib/portage/portage-stable"
 PORTDIR_OVERLAY="/var/lib/portage/coreos-overlay"
-PORTAGE_BINHOST="https://storage.googleapis.com/flatcar-jenkins/boards/${BOARD}/${FLATCAR_VERSION_ID}/pkgs/
-https://storage.googleapis.com/flatcar-jenkins/boards/${BOARD}/${FLATCAR_VERSION_ID}/toolchain/"
+PORTAGE_BINHOST="$(get_binhost_url 'pkgs')
+$(get_binhost_url 'toolchain')"
 EOF
 
 sudo_clobber "$1/etc/portage/repos.conf/coreos.conf" <<EOF

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -278,7 +278,7 @@ IMG_azure_OEM_PACKAGE=oem-azure
 ## azure pro
 IMG_azure_pro_DISK_FORMAT=vhd
 IMG_azure_pro_DISK_LAYOUT=azure
-IMG_azure_pro_OEM_PACKAGE=oem-azure
+IMG_azure_pro_OEM_PACKAGE=oem-azure-pro
 
 ## hyper-v
 IMG_hyperv_DISK_FORMAT=vhd


### PR DESCRIPTION
# Update the azure pro package reference to the oem-azure-pro

This commit updates the azure pro package reference to the oem-azure-pro. This commit also fixes the BINHOST URL for the developer container portage conf file

Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>


# How to use

```
./build_packages
./build_image
./image_to_vm --format=azure_pro
```

# Testing done
A Jenkins developer build which successfully picked the right oem package. The URL was verified in a developer container.

This need to be picked into the `flatcar-2643` branch

To be merged with kinvolk/coreos-overlay#710

