### PR TITLE
Add AWS Pro OEM type

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -8,6 +8,7 @@
 VALID_IMG_TYPES=(
     ami
     ami_vmdk
+    ami_vmdk_pro
     azure
     azure_pro
     brightbox
@@ -212,6 +213,10 @@ IMG_ami_OEM_USE=ec2
 IMG_ami_vmdk_DISK_FORMAT=vmdk_stream
 IMG_ami_vmdk_OEM_PACKAGE=oem-ec2-compat
 IMG_ami_vmdk_OEM_USE=ec2
+# AWS Pro
+IMG_ami_vmdk_pro_DISK_FORMAT=vmdk_stream
+IMG_ami_vmdk_pro_OEM_PACKAGE=oem-ec2-compat
+IMG_ami_vmdk_pro_OEM_USE=ec2
 
 ## openstack, supports ec2's metadata format so use oem-ec2-compat
 IMG_openstack_DISK_FORMAT=qcow2

--- a/jenkins/formats-amd64-usr.txt
+++ b/jenkins/formats-amd64-usr.txt
@@ -1,5 +1,6 @@
 ami
 ami_vmdk
+ami_vmdk_pro
 azure
 azure_pro
 gce

--- a/jenkins/vm.sh
+++ b/jenkins/vm.sh
@@ -44,7 +44,7 @@ img=src/flatcar_production_image.bin
 enter lbunzip2 -k -f "/mnt/host/source/${img}.bz2"
 
 PRIVATE_UPLOAD_OPT=""
-if [[ "${FORMAT}" == 'azure_pro' ]]
+if [[ "${FORMAT}" == 'azure_pro' ]] || [[ "${FORMAT}" == 'ami_vmdk_pro' ]]
 then
   PRIVATE_UPLOAD_OPT="--private"
   UPLOAD_ROOT=${UPLOAD_PRIVATE_ROOT}


### PR DESCRIPTION
This is the initial creation of an AWS Pro image coming with support,
and features added on top of it.

*Note:* Pick for 2605 and 2705

# How to use

# Testing done

Built image and ran kola tests