### PR TITLE
Add GCE Pro OEM type

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -18,6 +18,7 @@ VALID_IMG_TYPES=(
     digitalocean
     exoscale
     gce
+    gce_pro
     hyperv
     interoute
     iso
@@ -252,6 +253,12 @@ IMG_gce_DISK_LAYOUT=vm
 IMG_gce_CONF_FORMAT=gce
 IMG_gce_OEM_PACKAGE=oem-gce
 IMG_gce_OEM_ACI=gce
+
+## gce pro, image tarball
+IMG_gce_pro_DISK_LAYOUT=vm
+IMG_gce_pro_CONF_FORMAT=gce
+IMG_gce_pro_OEM_PACKAGE=oem-gce
+IMG_gce_pro_OEM_ACI=gce
 
 ## rackspace
 IMG_rackspace_OEM_PACKAGE=oem-rackspace

--- a/jenkins/formats-amd64-usr.txt
+++ b/jenkins/formats-amd64-usr.txt
@@ -4,6 +4,7 @@ ami_vmdk_pro
 azure
 azure_pro
 gce
+gce_pro
 iso
 pxe
 qemu

--- a/jenkins/vm.sh
+++ b/jenkins/vm.sh
@@ -43,8 +43,10 @@ img=src/flatcar_production_image.bin
 [[ "${img}.bz2" -nt "${img}" ]] &&
 enter lbunzip2 -k -f "/mnt/host/source/${img}.bz2"
 
+# If the format variable ends with _pro it's a Flatcar Pro image and it should
+# be uploaded to the private bucket.
 PRIVATE_UPLOAD_OPT=""
-if [[ "${FORMAT}" == 'azure_pro' ]] || [[ "${FORMAT}" == 'ami_vmdk_pro' ]]
+if [[ -z "${FORMAT##*_pro}" ]]
 then
   PRIVATE_UPLOAD_OPT="--private"
   UPLOAD_ROOT=${UPLOAD_PRIVATE_ROOT}


### PR DESCRIPTION
# Add GCE Pro OEM type

This adds gce_pro as one of the valid formats, currently it installs the `oem-gce` package.

# How to use / Testing done
Built image and run kola tests (vm-matrix 1896, kola/gce 366)

