### PR TITLE
build_library: Fix git URLs

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -299,7 +299,7 @@ get_metadata() {
     if [ "${key}" = "SRC_URI" ]; then
         local package_name="$(echo "${pkg%%:*}" | cut -d / -f 2)"
         local ebuild_path="${prefix}/var/db/pkg/${pkg%%:*}/${package_name}.ebuild"
-        # SRC_URI is empty for the special github.com/flatcar-linux projects
+        # SRC_URI is empty for the special github.com/kinvolk projects
         if [ -z "${val}" ]; then
             # The grep invocation gives errors when the ebuild file is not present.
             # This can happen if a "scripts" branch does not match the "coreos-overlay" branch
@@ -307,7 +307,7 @@ get_metadata() {
             val="$(grep "CROS_WORKON_PROJECT=" "${ebuild_path}" | cut -d '"' -f 2)"
             if [ -n "${val}" ]; then
                 val="https://github.com/${val}"
-                # All github.com/flatcar-linux projects specify their commit
+                # All github.com/kinvolk projects specify their commit
                 local commit=""
                 commit="$(grep "CROS_WORKON_COMMIT=" "${ebuild_path}" | cut -d '"' -f 2)"
                 if [ -n "${commit}" ]; then
@@ -347,7 +347,7 @@ get_metadata() {
 #       "licenses": ["GPL-2", "LGPL-2.1", "MIT", "public-domain"],
 #       "description": "System and service manager for Linux",
 #       "homepage": "https://www.freedesktop.org/wiki/Software/systemd",
-#       "source": "https://github.com/flatcar-linux/systemd ",
+#       "source": "https://github.com/kinvolk/systemd ",
 #       "files": "somefile 63a5736879fa647ac5a8d5317e7cb8b0\nsome -> link\n"
 #     }
 #   ]
@@ -441,9 +441,9 @@ You can read it with "less licenses.json.bz2" or convert it to a text format wit
 bzcat licenses.json.bz2 | jq -r '.[] | "\(.project):\nDescription: \(.description)\nLicenses: \(.licenses)\nHomepage: \(.homepage)\nSource code: \(.source)\nFiles:\n\(.files)\n"'
 The license texts are available under /usr/share/licenses/common/ and can be read with "less NAME.gz".
 Build system files and patches used to build these projects are located at:
-https://github.com/flatcar-linux/coreos-overlay/
-https://github.com/flatcar-linux/portage-stable/
-https://github.com/flatcar-linux/scripts/
+https://github.com/kinvolk/coreos-overlay/
+https://github.com/kinvolk/portage-stable/
+https://github.com/kinvolk/flatcar-scripts/
 Information on how to build Flatcar Container Linux can be found under:
 https://docs.flatcar-linux.org/os/sdk-modifying-flatcar/
 EOF

--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -49,12 +49,12 @@ disabled = true
 [coreos]
 location = /var/lib/portage/coreos-overlay
 sync-type = git
-sync-uri = https://github.com/flatcar-linux/coreos-overlay.git
+sync-uri = https://github.com/kinvolk/coreos-overlay.git
 
 [portage-stable]
 location = /var/lib/portage/portage-stable
 sync-type = git
-sync-uri = https://github.com/flatcar-linux/portage-stable.git
+sync-uri = https://github.com/kinvolk/portage-stable.git
 EOF
 
     # Now set the correct profile


### PR DESCRIPTION
The repos were moved to kinvolk. Redirects still work, but it's better
not to rely on them.