### PR TITLE
vm_image_util: Use new aws_pro flag for ec2-compat

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -217,7 +217,7 @@ IMG_ami_vmdk_OEM_USE=ec2
 # AWS Pro
 IMG_ami_vmdk_pro_DISK_FORMAT=vmdk_stream
 IMG_ami_vmdk_pro_OEM_PACKAGE=oem-ec2-compat
-IMG_ami_vmdk_pro_OEM_USE=ec2
+IMG_ami_vmdk_pro_OEM_USE=aws_pro
 
 ## openstack, supports ec2's metadata format so use oem-ec2-compat
 IMG_openstack_DISK_FORMAT=qcow2


### PR DESCRIPTION
# Use new aws_pro flag for ec2-compat package

When building the ec2-compat package for the ami_vmdk_pro image format, use the new aws_pro flag instead of the existing one.

It should be merged together with https://github.com/kinvolk/coreos-overlay/pull/794
