### PR TITLE
Improve the dependency cycle breaking logic

### DIFF
--- a/build_packages
+++ b/build_packages
@@ -266,11 +266,18 @@ break_dep_loop() {
 }
 
 if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_FALSE}" ]]; then
+  # Breaking the following loops here:
+  #
   # util-linux[udev] -> virtual->udev -> systemd -> util-linux
-  break_dep_loop sys-apps/util-linux udev,systemd sys-apps/systemd cryptsetup
-
-  # systemd[cryptsetup] -> cryptsetup -> lvm2 -> virtual/udev -> systemd
-  break_dep_loop sys-apps/systemd cryptsetup
+  # util-linux[systemd] -> systemd -> util-linux
+  # cryptsetup[udev] -> virtual/udev -> systemd[cryptsetup] -> cryptsetup
+  # lvm2[udev] -> virtual/udev -> systemd[cryptsetup] -> cryptsetup -> lvm2
+  # lvm2[systemd] -> systemd[cryptsetup] -> cryptsetup -> lvm2
+  # systemd[cryptsetup] -> cryptsetup[udev] -> virtual/udev -> systemd
+  break_dep_loop sys-apps/util-linux udev,systemd \
+                 sys-fs/cryptsetup udev \
+                 sys-fs/lvm2 udev,systemd \
+                 sys-apps/systemd cryptsetup
 fi
 
 export KBUILD_BUILD_USER="${BUILD_USER:-build}"

--- a/build_packages
+++ b/build_packages
@@ -186,44 +186,82 @@ fi
 # Goo to attempt to resolve dependency loops on individual packages.
 # If this becomes insufficient we will need to move to a full multi-stage
 # bootstrap process like we do with the SDK via catalyst.
+#
+# Called like:
+#
+#     break_dep_loop [PKG_USE_PAIR]…
+#
+# PKG_USE_PAIR consists of two arguments: a package name (for example:
+# sys-fs/lvm2), and a comma-separated list of USE flags to clear (for
+# example: udev,systemd).
 break_dep_loop() {
-  local pkg="$1"
-  local flags=( ${2//,/ } )
-  shift 2
+  local -a pkgs
+  local -a all_flags
+  local -a args
   local flag_file="${BOARD_ROOT}/etc/portage/package.use/break_dep_loop"
+  local -a flag_file_entries
+  local -a pkg_summaries
 
   # Be sure to clean up use flag hackery from previous failed runs
   sudo rm -f "${flag_file}"
 
-  # If the package is already installed we have nothing to do
-  if portageq-"${BOARD}" has_version "${BOARD_ROOT}" "${pkg}"; then
-    return 0
+  if [[ $# -eq 0 ]]; then
+      return 0
   fi
 
-  # Likewise, nothing to do if the flag isn't actually enabled.
-  if ! pkg_use_enabled "${pkg}" "${flags[@]}"; then
-    return 0
-  fi
-
-  # Temporarily compile/install package with flag disabled. If a binary
+  # Temporarily compile/install packages with flags disabled. If a binary
   # package is available use it regardless of its version or use flags.
-  local disabled_flags="${flags[@]/#/-}"
-  info "Merging ${pkg} with USE=${disabled_flags}"
-  sudo mkdir -p "${flag_file%/*}"
-  sudo_clobber "${flag_file}" <<<"${pkg} ${disabled_flags}"
-  # Disable any other problematic flags
-  extra_args=""
+  local pkg
+  local -a flags
+  local disabled_flags
   while [[ $# -gt 0 ]]; do
-      sudo_append "${flag_file}" <<<"$1 -$2"
-      extra_args+=" --buildpkg-exclude=$1 --useoldpkg-atoms=$1"
-      shift 2
+    pkg="${1}"
+    pkgs+=("${pkg}")
+    flags=( ${2//,/ } )
+    all_flags+=("${flags[@]}")
+    disabled_flags="${flags[@]/#/-}"
+    flag_file_entries+=("${pkg} ${disabled_flags}")
+    args+=("--buildpkg-exclude=${pkg}")
+    pkg_summaries+=("${pkg}[${disabled_flags}]")
+    shift 2
+  done
+
+  # If packages are already installed we have nothing to do
+  local any_package_uninstalled=0
+  for pkg in "${pkgs[@]}"; do
+    if ! portageq-"${BOARD}" has_version "${BOARD_ROOT}" "${pkgs[@]}"; then
+      any_package_uninstalled=1
+      break
+    fi
+  done
+  if [[ ${any_package_uninstalled} -eq 0 ]]; then
+    return 0
+  fi
+
+  # Likewise, nothing to do if the flags aren't actually enabled.
+  local any_flag_enabled=0
+  for pkg in "${pkgs[@]}"; do
+    if pkg_use_enabled "${pkg}" "${all_flags[@]}"; then
+      any_flag_enabled=1
+      break
+    fi
+  done
+  if [[ ${any_flag_enabled} -eq 0 ]]; then
+    return 0
+  fi
+
+  info "Merging ${pkg_summaries[@]}"
+  sudo mkdir -p "${flag_file%/*}"
+  sudo_clobber "${flag_file}" <<<"${flag_file_entries[0]}"
+  local entry
+  for entry in "${flag_file_entries[@]:1}"; do
+    sudo_append "${flag_file}" <<<"${entry}"
   done
   # rebuild-if-unbuilt is disabled to prevent portage from needlessly
   # rebuilding zlib for some unknown reason, in turn triggering more rebuilds.
   sudo -E "${EMERGE_CMD[@]}" "${EMERGE_FLAGS[@]}" \
-      --rebuild-if-unbuilt=n \
-      --buildpkg-exclude="${pkg}" \
-      ${extra_args} "${pkg}"
+    --rebuild-if-unbuilt=n \
+    "${args[@]}" "${pkgs[@]}"
   sudo rm -f "${flag_file}"
 }
 


### PR DESCRIPTION
The `break_dep_loop` function is updated to take pairs of package name and multiple USE flags to be disabled, and makes sure all the packages in pairs are rebuilt. That way it's more robust against package build ordering.

In our case the issue was that we had a dependency cycle like `sys-apps/systemd` -> `sys-fs/cryptsetup` -> `virtual/udev` -> `sys-apps/systemd`. We were breaking the cycle at the first arrow, thus not building `sys-fs/cryptsetup` in dependency-cycle-breaking emerge as it was not pulled by anything else as a dependency. When doing the rest-of-the-packages-building emerge, `sys-fs/cryptsetup` was built and `sys-apps/systemd` was rebuilt, in that order. But after updating portage to a newer version, the order was reversed and `sys-apps/systemd` failed during the configure phase, because it depends on a yet unbuilt `sys-fs/cryptsetup`. I think that the building order of packages that are in the dependency cycle is arbitrary, so to guard against such a scenario we build all the packages in the dependency cycle. That way, when rebuilding them in any order we are sure that their dependencies are already installed either by the dependency-cycle-breaking emerge or the rest-of-the-packages-building emerge.

This change has moved updating portage forward.

Test build: http://localhost:9091/job/os/job/manifest/1950/cldsv/ (arm64 build failure is because some nvidia drivers are missing the keyword changes).