### PR TITLE
build_library/catalyst.sh: Fix paths to ebuild repos

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -91,10 +91,10 @@ main-repo = portage-stable
 disabled = true
 
 [coreos]
-location = /usr/portage
+location = /var/gentoo/repos/local
 
 [portage-stable]
-location = /usr/local/portage
+location = /var/gentoo/repos/gentoo
 EOF
 }
 


### PR DESCRIPTION
I have no idea how this thing worked before - the repos never were in
/usr/portage nor in /usr/local/portage… But the newer version of
portage seems to be pretty picky about the validity of repos location,
so fix them.

This fixes some issues appearing during the stage4/fsscript of the catalyst build with updated portage.

Test build: http://localhost:9091/job/os/job/manifest/1951/cldsv (arm64 packages matrix failed because of some nvidia stuff)