### PR TITLE
setup_board: Copy repos.conf earlier

### DIFF
--- a/setup_board
+++ b/setup_board
@@ -235,6 +235,7 @@ fi
 
 info "Configuring portage in ${BOARD_ROOT}"
 sudo mkdir -p "${BOARD_ETC}/portage/"{profile,repos.conf}
+sudo cp /etc/portage/repos.conf/* "${BOARD_ETC}"/portage/repos.conf/
 sudo ROOT="${BOARD_ROOT}" eselect profile set --force "${PORTAGE_PROFILE}"
 
 # Cleanup/migrate from older make.conf files
@@ -273,8 +274,6 @@ EMERGE_DEFAULT_OPTS="--oneshot"
 # Allow the user to override or define additional settings.
 source "${BOARD_ETC}/portage/make.conf.user"
 EOF
-
-sudo cp /etc/portage/repos.conf/* "${BOARD_ETC}"/portage/repos.conf/
 
 # required when using --regen_configs_only
 sudo mkdir -p --mode=01777 "${BOARD_ROOT}"{/tmp,/var/tmp}


### PR DESCRIPTION
eselect calls "portage get_repo_path /build/amd64-usr coreos" at some
point. Before updating portage, portageq seemed to take all the
information not from /build/amd64-usr (which at the time contained no
repo information at all), but rather from /. The newer version of
portageq seems to respect the passed root now, so it actually tries to
consult the nonexistent repos configuration in /build/amd64-usr and
fails. To avoid the failure, perform the copying of the configuration
files earlier.

Test build: http://localhost:9091/job/os/job/manifest/1953/cldsv/ (arm64 failed at packages matrix because of some nvidia stuff)