### PR TITLE
bootstrap_sdk, build_toolchains: Move the ROOT_OVERLAY variable

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -40,8 +40,6 @@ TYPE="flatcar-sdk"
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1
 
-ROOT_OVERLAY=${TEMPDIR}/stage4_overlay
-
 ## Define the stage4 config template
 catalyst_stage4() {
 cat <<EOF
@@ -63,6 +61,7 @@ export GENTOO_MIRRORS
 
 catalyst_init "$@"
 check_gsutil_opts
+ROOT_OVERLAY=${TEMPDIR}/stage4_overlay
 
 if [[ "$STAGES" =~ stage4 ]]; then
     info "Setting release to ${FLATCAR_VERSION}"

--- a/build_toolchains
+++ b/build_toolchains
@@ -15,8 +15,6 @@ FORCE_STAGES="stage4"
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1
 
-ROOT_OVERLAY="${TEMPDIR}/stage4-${ARCH}-$FLAGS_version-overlay"
-
 ## Define the stage4 config template
 catalyst_stage4() {
 cat <<EOF
@@ -31,6 +29,8 @@ catalyst_stage_default
 
 catalyst_init "$@"
 check_gsutil_opts
+
+ROOT_OVERLAY="${TEMPDIR}/stage4-${ARCH}-$FLAGS_version-overlay"
 
 # toolchain_util.sh is required by catalyst_toolchains.sh
 mkdir -p "${ROOT_OVERLAY}/tmp"


### PR DESCRIPTION
ROOT_OVERLAY variable is defined in terms of TEMPDIR. The TEMPDIR
variable is set to an empty value by catalyst.sh, which the two
scripts import. So ROOT_OVERLAY always ended up being located in
toplevel directory (i.e. `/`). But the TEMPDIR variable gets a
meaningful value after calling the catalyst_init function, so define
the ROOT_OVERLAY after the function is called.

This doesn't fix any failure, but makes sure that this directory is placed somewhere within the directory with the rest of the catalyst stuff resides.

Test build: http://localhost:9091/job/os/job/manifest/1954/cldsv/ (arm64 failed at packages matrix due to some nvidia stuff, unrelated to this PR)