### PR TITLE
torcx: delete docker 1.12

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -237,7 +237,6 @@ function torcx_package() {
 # for each package will point at the last version specified.  This can handle
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
-        =app-torcx/docker-1.12
         =app-torcx/docker-19.03
 )
 


### PR DESCRIPTION
Now that Docker 1.12 is gone, we need to also exclude docker 1.12 from the list of torcx stores.

This PR should be merged together with https://github.com/kinvolk/coreos-overlay/pull/826.

## How to use

```
./build_packages
```

## Testing done

CI passed: http://localhost:9091/job/os/job/manifest/1960/cldsv/