### PR TITLE
Fix missing jobs parameter

### DIFF
--- a/build_docker_aci
+++ b/build_docker_aci
@@ -54,6 +54,8 @@ DEFINE_string version "" \
   "Sets the docker version to build."
 DEFINE_integer aci_version "" \
   "Sets the aci version tag identifier."
+DEFINE_integer jobs "${NUM_JOBS}" \
+  "How many packages to build in parallel at maximum."
 
 # Parse command line.
 FLAGS "$@" || exit 1

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -522,6 +522,7 @@ install_oem_aci() {
     "${SCRIPT_ROOT}/build_oem_aci" \
         --board="${BOARD}" \
         --build_dir="${aci_dir}" \
+        --jobs="${FLAGS_jobs}" \
         "${binpkgflags[@]}" \
         "${oem_aci}"
 

--- a/build_oem_aci
+++ b/build_oem_aci
@@ -46,6 +46,8 @@ DEFINE_string output_root "${DEFAULT_BUILD_ROOT}/images" \
   "Directory in which to place image result directories (named by version)"
 DEFINE_string version "" \
   "Overrides version number in name to this version."
+DEFINE_integer jobs "${NUM_JOBS}" \
+  "How many packages to build in parallel at maximum."
 
 # Parse command line.
 FLAGS "$@" || exit 1


### PR DESCRIPTION
`build_docker_aci` and `build_oem_aci` at some point call the `emerge_to_image` function which uses the `$FLAGS_jobs` variable in `emerge` parameter `--jobs=$FLAGS_jobs`. But the scripts did not define such a flag, which resulted in calling `emerge` with `--jobs=`. Apparently updated portage didn't like that (it interpreted empty value as a string and was later throwing an exception when portage tried to compare a string to number with `<`).

Tested during release.