### PR TITLE
image_to_vm.sh: Explicity mention the jobs param in image_to_vm step

### DIFF
--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -44,6 +44,8 @@ DEFINE_boolean getbinpkg "${FLAGS_FALSE}" \
   "Download binary packages from remote repository."
 DEFINE_string getbinpkgver "" \
   "Use binary packages from a specific version."
+DEFINE_integer jobs "${NUM_JOBS}" \
+  "How many packages to build in parallel at maximum."
 
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1


### PR DESCRIPTION

# image_to_vm.sh: Explicity mention the jobs param in image_to_vm step

Now, in the oem aci creation step, we make use of the jobs param.
Without this flag, an empty string is passed to emerge which results
in failure.

# How to use

```bash
./build_image
./image_to_vm.sh --from=.......... --board=amd64-usr --format=gce
```

# Testing done

Locally tested.

