### PR TITLE
Drop `--jobs` parameter

### DIFF
--- a/build_docker_aci
+++ b/build_docker_aci
@@ -54,8 +54,6 @@ DEFINE_string version "" \
   "Sets the docker version to build."
 DEFINE_integer aci_version "" \
   "Sets the aci version tag identifier."
-DEFINE_integer jobs "${NUM_JOBS}" \
-  "How many packages to build in parallel at maximum."
 
 # Parse command line.
 FLAGS "$@" || exit 1

--- a/build_image
+++ b/build_image
@@ -72,8 +72,6 @@ show_help_if_requested "$@"
 # not needed for the typical developer workflow.
 DEFINE_integer build_attempt 1 \
   "The build attempt for this image build."
-DEFINE_integer jobs "${NUM_JOBS}" \
-  "How many packages to build in parallel at maximum."
 DEFINE_boolean replace ${FLAGS_FALSE} \
   "Overwrite existing output, if any."
 DEFINE_string version "" \

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -145,7 +145,7 @@ emerge_to_image() {
 
   sudo -E ROOT="${root_fs_dir}" \
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
-      emerge --root-deps=rdeps --usepkgonly --jobs=$FLAGS_jobs -v "$@"
+      emerge --root-deps=rdeps --usepkgonly --jobs="${NUM_JOBS}" -v "$@"
 
   # Shortcut if this was just baselayout
   [[ "$*" == *sys-apps/baselayout ]] && return
@@ -172,7 +172,7 @@ emerge_to_image_unchecked() {
 
   sudo -E ROOT="${root_fs_dir}" \
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
-      emerge --root-deps=rdeps --usepkgonly --jobs=$FLAGS_jobs -v "$@"
+      emerge --root-deps=rdeps --usepkgonly --jobs="${NUM_JOBS}" -v "$@"
 
   # Shortcut if this was just baselayout
   [[ "$*" == *sys-apps/baselayout ]] && return

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -522,7 +522,6 @@ install_oem_aci() {
     "${SCRIPT_ROOT}/build_oem_aci" \
         --board="${BOARD}" \
         --build_dir="${aci_dir}" \
-        --jobs="${FLAGS_jobs}" \
         "${binpkgflags[@]}" \
         "${oem_aci}"
 

--- a/build_oem_aci
+++ b/build_oem_aci
@@ -46,8 +46,6 @@ DEFINE_string output_root "${DEFAULT_BUILD_ROOT}/images" \
   "Directory in which to place image result directories (named by version)"
 DEFINE_string version "" \
   "Overrides version number in name to this version."
-DEFINE_integer jobs "${NUM_JOBS}" \
-  "How many packages to build in parallel at maximum."
 
 # Parse command line.
 FLAGS "$@" || exit 1

--- a/build_packages
+++ b/build_packages
@@ -30,8 +30,6 @@ DEFINE_boolean workon "${FLAGS_TRUE}" \
   "Automatically rebuild updated cros-workon packages."
 DEFINE_boolean fetchonly "${FLAGS_FALSE}" \
   "Don't build anything, instead only fetch what is needed."
-DEFINE_integer jobs "${NUM_JOBS}" \
-  "How many packages to build in parallel at maximum."
 DEFINE_boolean rebuild "${FLAGS_FALSE}" \
   "Automatically rebuild dependencies."
 DEFINE_boolean skip_toolchain_update "${FLAGS_FALSE}" \
@@ -113,9 +111,6 @@ if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
 else
   UPDATE_ARGS+=( --nousepkg )
 fi
-if [[ "${FLAGS_jobs}" -ne -1 ]]; then
-  UPDATE_ARGS+=( --jobs=${FLAGS_jobs} )
-fi
 if [ "${FLAGS_skip_toolchain_update}" -eq "${FLAGS_TRUE}" ]; then
   UPDATE_ARGS+=( --skip_toolchain_update )
 fi
@@ -161,10 +156,8 @@ if [[ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]]; then
   fi
 fi
 
-if [[ "${FLAGS_jobs}" -ne -1 ]]; then
-  EMERGE_FLAGS+=( --jobs=${FLAGS_jobs} )
-  REBUILD_FLAGS+=( --jobs=${FLAGS_jobs} )
-fi
+EMERGE_FLAGS+=( "--jobs=${NUM_JOBS}" )
+REBUILD_FLAGS+=( "--jobs=${NUM_JOBS}" )
 
 if [[ "${FLAGS_rebuild}" -eq "${FLAGS_TRUE}" ]]; then
   EMERGE_FLAGS+=( --rebuild-if-unbuilt )

--- a/common.sh
+++ b/common.sh
@@ -8,7 +8,10 @@
 
 # The number of jobs to pass to tools that can run in parallel (such as make
 # and dpkg-buildpackage
-if [[ -z ${NUM_JOBS} ]]; then
+case "${NUM_JOBS}" in
+  *[!0-9]*) NUM_JOBS='' ;;
+esac
+if [[ -z ${NUM_JOBS} ]] || [[ ${NUM_JOBS} -eq 0 ]]; then
   NUM_JOBS=$(grep -c "^processor" /proc/cpuinfo)
 fi
 # Ensure that any sub scripts we invoke get the max proc count.

--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -44,8 +44,6 @@ DEFINE_boolean getbinpkg "${FLAGS_FALSE}" \
   "Download binary packages from remote repository."
 DEFINE_string getbinpkgver "" \
   "Use binary packages from a specific version."
-DEFINE_integer jobs "${NUM_JOBS}" \
-  "How many packages to build in parallel at maximum."
 
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1

--- a/rebuild_packages
+++ b/rebuild_packages
@@ -15,8 +15,6 @@ assert_not_root_user
 # Developer-visible flags.
 DEFINE_string board "${DEFAULT_BOARD}" \
   "The board to build packages for."
-DEFINE_integer jobs "${NUM_JOBS}" \
-  "How many packages to build in parallel."
 
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1
@@ -76,7 +74,7 @@ if [[ "${#rebuild_atoms[@]}" -eq 0 ]]; then
     info "No ebuild changes detected"
 else
     info "Rebuilding ${#rebuild_atoms[@]} packages..."
-    emerge-$BOARD --jobs=${FLAGS_jobs} "${rebuild_atoms[@]}"
+    emerge-$BOARD "--jobs=${NUM_JOBS}" "${rebuild_atoms[@]}"
 
     info "Checking build root"
     test_image_content "${BOARD_ROOT}"

--- a/setup_board
+++ b/setup_board
@@ -31,8 +31,6 @@ DEFINE_string binhost "" \
   "Use binary packages from a specific location (e.g. https://storage.googleapis.com/flatcar-jenkins/sdk/amd64/2000.0.0/pkgs)"
 DEFINE_boolean toolchainpkgonly "${FLAGS_FALSE}" \
   "Use binary packages only for the board toolchain."
-DEFINE_integer jobs "${NUM_JOBS}" \
-  "How many packages to build in parallel at maximum."
 DEFINE_boolean skip_toolchain_update "${FLAGS_FALSE}" \
   "Don't update toolchain automatically."
 DEFINE_boolean skip_chroot_upgrade "${FLAGS_FALSE}" \
@@ -206,9 +204,6 @@ if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
 else
   UPDATE_ARGS+=" --nousepkg"
 fi
-if [[ "${FLAGS_jobs}" -ne -1 ]]; then
-  UPDATE_ARGS+=" --jobs=${FLAGS_jobs}"
-fi
 if [ "${FLAGS_skip_toolchain_update}" -eq "${FLAGS_TRUE}" ]; then
   UPDATE_ARGS+=" --skip_toolchain_update"
 fi
@@ -295,9 +290,7 @@ ${EMAINT_WRAPPER} --fix world
 
 if [[ ${FLAGS_regen_configs} -eq ${FLAGS_FALSE} ]]; then
   EMERGE_FLAGS="--select --quiet --root-deps=rdeps"
-  if [[ "${FLAGS_jobs}" -ne -1 ]]; then
-    EMERGE_FLAGS+=" --jobs=${FLAGS_jobs}"
-  fi
+  EMERGE_FLAGS+=" --jobs=${NUM_JOBS}"
   EMERGE_TOOLCHAIN_FLAGS="${EMERGE_FLAGS}"
 
   if [[ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}"  && \

--- a/update_chroot
+++ b/update_chroot
@@ -21,8 +21,6 @@ DEFINE_boolean usepkgonly "${FLAGS_FALSE}" \
   "Only use/download binary packages. Implies --noworkon"
 DEFINE_boolean workon "${FLAGS_TRUE}" \
   "Automatically rebuild updated cros-workon packages."
-DEFINE_integer jobs "${NUM_JOBS}" \
-  "How many packages to build in parallel at maximum."
 DEFINE_boolean skip_toolchain_update "${FLAGS_FALSE}" \
   "Don't update the toolchains."
 DEFINE_string toolchain_boards "" \
@@ -201,10 +199,8 @@ if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
   REBUILD_FLAGS+=( $(get_binonly_args $(get_chost_list)) )
 fi
 
-if [[ "${FLAGS_jobs}" -ne -1 ]]; then
-  EMERGE_FLAGS+=( "--jobs=${FLAGS_jobs}" )
-  REBUILD_FLAGS+=( "--jobs=${FLAGS_jobs}" )
-fi
+EMERGE_FLAGS+=( "--jobs=${NUM_JOBS}" )
+REBUILD_FLAGS+=( "--jobs=${NUM_JOBS}" )
 
 # Perform an update of coreos-devel/sdk-depends and world in the chroot.
 EMERGE_CMD="emerge"


### PR DESCRIPTION
The `--jobs` parameter that some scripts defined was not used anywhere
in jenkins or mantle. So the value of the parameter always ended up
being equal to `${NUM_JOBS}` set by `common.sh`. Also, even if the
`--jobs` parameter was used for some script, that script sometimes
didn't forward the jobs value to other scripts, so the other scripts
ended up using `${NUM_JOBS}` again. Also, the `${FLAGS_jobs}` variable
was used by some functions in the build library, and those functions
were sometimes invoked by scripts that didn't define the
`${FLAGS_jobs}` variable. It is tedious to track which script should
actually define the parameter, and where it should be forwarded.

Just get rid of this half-working pretense. If you want to affect how
many jobs `emerge` uses, export the `NUM_JOBS` environment variable
before calling any script.

For `EMERGE_FLAGS` and `REBUILD_FLAGS` we unconditionally specify the
`--jobs` flag's value to `${NUM_JOBS}` because they are passed to
`emerge`. On the other hand we drop the `--jobs` parameter from the
`UPDATE_ARGS` variable, because this variable passed to `setup_board`
or `update_chroot`, which don't have this flag any more.

Also make sure that NUM_JOBS is a positive integer.