### PR TITLE
build_library/break_dep_loop: add to library

### DIFF
--- a/build_library/break_dep_loop.sh
+++ b/build_library/break_dep_loop.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Copyright (c) 2021 The Flatcar Maintainers.
+# Based on work (c) 2011 The Chromium OS Authors.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Goo to attempt to resolve dependency loops on individual packages.
+#
+# Called like:
+#
+#     break_dep_loop [PKG_USE_PAIR]…
+#
+# PKG_USE_PAIR consists of two arguments: a package name (for example:
+# sys-fs/lvm2), and a comma-separated list of USE flags to clear (for
+# example: udev,systemd).
+#
+# For example - given a build error like:
+#
+# | * Error: circular dependencies:
+# |
+# |  (sys-apps/systemd-247.6:0/2::coreos, [...]
+# |   (sys-apps/util-linux-2.33-r1:0/0::portage-stable, [...]
+# |     (sys-apps/systemd-247.6:0/2::coreos, [...]
+# |
+# |     It might be possible to break this cycle
+# |     by applying any of the following changes:
+# |     - sys-apps/util-linux-2.33-r1 (Change USE: -systemd)
+# |     - sys-apps/util-linux-2.33-r1 (Change USE: +build)
+#
+# Use:
+#
+#    break_dep_loop sys-apps/util-linux systemd
+#
+# to break the loop.
+
+break_dep_loop() {
+  local -a pkgs
+  local -a all_flags
+  local -a args
+  local -a flag_file_entries
+  local -a pkg_summaries
+
+  if [ -z "${BOARD_ROOT}" ] ; then
+    local BOARD_ROOT="${ROOT}"
+  fi
+  local flag_file="${BOARD_ROOT}/etc/portage/package.use/break_dep_loop"
+
+  # Be sure to clean up use flag hackery from previous failed runs
+  sudo rm -f "${flag_file}"
+
+  if [[ $# -eq 0 ]]; then
+      return 0
+  fi
+
+  # Temporarily compile/install packages with flags disabled. If a binary
+  # package is available use it regardless of its version or use flags.
+  local pkg
+  local -a flags
+  local disabled_flags
+  while [[ $# -gt 0 ]]; do
+    pkg="${1}"
+    pkgs+=("${pkg}")
+    flags=( ${2//,/ } )
+    all_flags+=( "${flags[@]}" )
+    disabled_flags="${flags[@]/#/-}"
+    flag_file_entries+=("${pkg} ${disabled_flags}")
+    args+=("--buildpkg-exclude=${pkg}")
+    pkg_summaries+=("${pkg}[${disabled_flags}]")
+    shift 2
+  done
+
+  # If packages are already installed we have nothing to do
+  local portageq
+  if [ -n "${BOARD}" ] ; then
+    portageq="portageq-${BOARD}"
+  else
+    portageq="portageq"
+    local BOARD_ROOT="${ROOT}"
+  fi
+  local any_package_uninstalled=0
+  for pkg in "${pkgs[@]}"; do
+    if ! ${portageq}  has_version "${BOARD_ROOT}" "${pkgs[@]}"; then
+      any_package_uninstalled=1
+      break
+    fi
+  done
+  if [[ ${any_package_uninstalled} -eq 0 ]]; then
+    echo "break_dep_loop: Package(s) ${pkgs[@]} already installed, nothing to do."
+    return 0
+  fi
+
+  # Likewise, nothing to do if the flags aren't actually enabled.
+  local equery="equery"
+  if [ -n "${BOARD}" ] ; then
+    equery="equery-${BOARD}"
+  fi
+  local any_flag_enabled=0
+  for pkg in "${pkgs[@]}"; do
+    local grep_args="${all_flags[@]/#/-e ^+}"
+    if ${equery} -q uses "${pkg}" | grep -q ${grep_args}; then
+      any_flag_enabled=1
+      break
+    fi
+  done
+  if [[ ${any_flag_enabled} -eq 0 ]]; then
+    echo "break_dep_loop: None of the USE Flag(s) ${all_flags} are enabled for ${pkgs[@]}, nothing to do."
+    return 0
+  fi
+
+  echo "break_dep_loop: Merging ${pkg_summaries[@]}"
+  sudo mkdir -p "${flag_file%/*}"
+  sudo tee "${flag_file}" >/dev/null <<<"${flag_file_entries[0]}"
+  local entry
+  for entry in "${flag_file_entries[@]:1}"; do
+    sudo tee -a "${flag_file}" >/dev/null <<<"${entry}"
+  done
+  if [ -z "${EMERGE_CMD[@]}" ]; then
+    local -a EMERGE_CMD=( "emerge" )
+  fi
+  # rebuild-if-unbuilt is disabled to prevent portage from needlessly
+  # rebuilding zlib for some unknown reason, in turn triggering more rebuilds.
+  sudo -E \
+    "${EMERGE_CMD[@]}" "${EMERGE_FLAGS[@]}" \
+    --rebuild-if-unbuilt=n \
+    "${args[@]}" "${pkgs[@]}"
+  sudo rm -f "${flag_file}"
+}

--- a/build_library/catalyst_toolchains.sh
+++ b/build_library/catalyst_toolchains.sh
@@ -3,6 +3,7 @@
 set -e
 source /tmp/chroot-functions.sh
 source /tmp/toolchain_util.sh
+source /tmp/break_dep_loop.sh
 
 # A note on packages:
 # The default PKGDIR is /usr/portage/packages
@@ -10,7 +11,7 @@ source /tmp/toolchain_util.sh
 # crossdev build packages use ${PKGDIR}/crossdev (uploaded to SDK location)
 # build deps in crossdev's sysroot use ${PKGDIR}/cross/${CHOST} (no upload)
 # native toolchains use ${PKGDIR}/target/${BOARD} (uploaded to board location)
-
+set -x
 configure_target_root() {
     local board="$1"
     local cross_chost=$(get_board_chost "$1")

--- a/build_packages
+++ b/build_packages
@@ -176,89 +176,10 @@ if [[ ${#CROS_WORKON_PKGS[@]} -gt 0 ]]; then
   )
 fi
 
-# Goo to attempt to resolve dependency loops on individual packages.
-# If this becomes insufficient we will need to move to a full multi-stage
-# bootstrap process like we do with the SDK via catalyst.
-#
-# Called like:
-#
-#     break_dep_loop [PKG_USE_PAIR]…
-#
-# PKG_USE_PAIR consists of two arguments: a package name (for example:
-# sys-fs/lvm2), and a comma-separated list of USE flags to clear (for
-# example: udev,systemd).
-break_dep_loop() {
-  local -a pkgs
-  local -a all_flags
-  local -a args
-  local flag_file="${BOARD_ROOT}/etc/portage/package.use/break_dep_loop"
-  local -a flag_file_entries
-  local -a pkg_summaries
-
-  # Be sure to clean up use flag hackery from previous failed runs
-  sudo rm -f "${flag_file}"
-
-  if [[ $# -eq 0 ]]; then
-      return 0
-  fi
-
-  # Temporarily compile/install packages with flags disabled. If a binary
-  # package is available use it regardless of its version or use flags.
-  local pkg
-  local -a flags
-  local disabled_flags
-  while [[ $# -gt 0 ]]; do
-    pkg="${1}"
-    pkgs+=("${pkg}")
-    flags=( ${2//,/ } )
-    all_flags+=("${flags[@]}")
-    disabled_flags="${flags[@]/#/-}"
-    flag_file_entries+=("${pkg} ${disabled_flags}")
-    args+=("--buildpkg-exclude=${pkg}")
-    pkg_summaries+=("${pkg}[${disabled_flags}]")
-    shift 2
-  done
-
-  # If packages are already installed we have nothing to do
-  local any_package_uninstalled=0
-  for pkg in "${pkgs[@]}"; do
-    if ! portageq-"${BOARD}" has_version "${BOARD_ROOT}" "${pkgs[@]}"; then
-      any_package_uninstalled=1
-      break
-    fi
-  done
-  if [[ ${any_package_uninstalled} -eq 0 ]]; then
-    return 0
-  fi
-
-  # Likewise, nothing to do if the flags aren't actually enabled.
-  local any_flag_enabled=0
-  for pkg in "${pkgs[@]}"; do
-    if pkg_use_enabled "${pkg}" "${all_flags[@]}"; then
-      any_flag_enabled=1
-      break
-    fi
-  done
-  if [[ ${any_flag_enabled} -eq 0 ]]; then
-    return 0
-  fi
-
-  info "Merging ${pkg_summaries[@]}"
-  sudo mkdir -p "${flag_file%/*}"
-  sudo_clobber "${flag_file}" <<<"${flag_file_entries[0]}"
-  local entry
-  for entry in "${flag_file_entries[@]:1}"; do
-    sudo_append "${flag_file}" <<<"${entry}"
-  done
-  # rebuild-if-unbuilt is disabled to prevent portage from needlessly
-  # rebuilding zlib for some unknown reason, in turn triggering more rebuilds.
-  sudo -E "${EMERGE_CMD[@]}" "${EMERGE_FLAGS[@]}" \
-    --rebuild-if-unbuilt=n \
-    "${args[@]}" "${pkgs[@]}"
-  sudo rm -f "${flag_file}"
-}
-
 if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_FALSE}" ]]; then
+
+   . "${BUILD_LIBRARY_DIR}/break_dep_loop.sh" || exit 1
+
   # Breaking the following loops here:
   #
   # util-linux[udev] -> virtual->udev -> systemd -> util-linux

--- a/build_toolchains
+++ b/build_toolchains
@@ -33,8 +33,10 @@ check_gsutil_opts
 ROOT_OVERLAY="${TEMPDIR}/stage4-${ARCH}-$FLAGS_version-overlay"
 
 # toolchain_util.sh is required by catalyst_toolchains.sh
+# break_dep_loop.sh is required by toolchain_util.sh
 mkdir -p "${ROOT_OVERLAY}/tmp"
 cp "${BUILD_LIBRARY_DIR}/toolchain_util.sh" "${ROOT_OVERLAY}/tmp"
+cp "${BUILD_LIBRARY_DIR}/break_dep_loop.sh" "${ROOT_OVERLAY}/tmp"
 
 catalyst_build
 

--- a/common.sh
+++ b/common.sh
@@ -501,20 +501,6 @@ remove_quotes() {
   echo "$1" | sed -e "s/^'//; s/'$//"
 }
 
-# Writes stdin to the given file name as root using sudo in overwrite mode.
-#
-# $1 - The output file name.
-sudo_clobber() {
-  sudo tee "$1" >/dev/null
-}
-
-# Writes stdin to the given file name as root using sudo in append mode.
-#
-# $1 - The output file name.
-sudo_append() {
-  sudo tee -a "$1" >/dev/null
-}
-
 # Execute multiple commands in a single sudo. Generally will speed things
 # up by avoiding multiple calls to `sudo`. If any commands fail, we will
 # call die with the failing command. We can handle a max of ~100 commands,


### PR DESCRIPTION
This change moves `break_dep_loop` from `build_packages` into its own library script so it can be used from `build_packages` and `build_toolchains` / `toolchain_util.sh`.

`toolchain_util.sh` now calls break_dep_loop to break a dependency loop between util-linux and systemd which was introduced by the glibc-2.33 update. toolchain_util.sh further modifies USE flags to work around build breakage; both is done in install_cross_libs.

This PR is based on @dongsupark 's good work, here: https://github.com/kinvolk/flatcar-scripts/compare/dongsu/libpcre-8.44