### PR TITLE
catalyst_toolchains: don't touch the SDK

### DIFF
--- a/build_library/catalyst_toolchains.sh
+++ b/build_library/catalyst_toolchains.sh
@@ -39,15 +39,6 @@ build_target_toolchain() {
 
 configure_crossdev_overlay / /tmp/crossdev
 
-# TODO: this is building the SDK packages and shouldn't actually be needed
-for cross_chost in $(get_chost_list); do
-    echo "Building cross toolchain for ${cross_chost}"
-    PKGDIR="$(portageq envvar PKGDIR)/crossdev" \
-        install_cross_toolchain "${cross_chost}" ${clst_myemergeopts}
-    PKGDIR="$(portageq envvar PKGDIR)/cross/${cross_chost}" \
-        install_cross_libs "${cross_chost}" ${clst_myemergeopts}
-done
-
 for board in $(get_board_list); do
     echo "Building native toolchain for ${board}"
     target_pkgdir="$(portageq envvar PKGDIR)/target/${board}"


### PR DESCRIPTION
This change removes 8 years old code from the toolchains build which tries to update SDK libraries for unknown reasons, breaking the toolchains build in the glibc-2.33 update since touching the SDK triggers a circular dependency otherwise unseen.

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>