### PR TITLE
switch default torcx build to docker-20

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -237,13 +237,12 @@ function torcx_package() {
 # for each package will point at the last version specified.  This can handle
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
-        =app-torcx/docker-19.03
+        =app-torcx/docker-20.10
 )
 
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
-	=app-torcx/docker-17.03
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION

# switch default torcx build to docker-20

This switches the default torcx build to docker-20 and removes older torcx packages. Older docker versions don't support cgroupv2 which is also enabled at the same time.

## How to use

Pull this and kinvolk/coreos-overlay#931.
`./build_image`

## Testing done

Builds successfully. Still need to run the change through jenkins.
