### PR TITLE
Generate test update payload and run the kola update test

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -62,6 +62,17 @@ extract_update() {
   "${BUILD_LIBRARY_DIR}/disk_util" --disk_layout="${disk_layout}" \
     extract "${BUILD_DIR}/${image_name}" "USR-A" "${update_path}"
   upload_image "${update_path}"
+
+  # For production as well as dev builds we generate a dev-key-signed update
+  # payload for running tests (the signature won't be accepted by production systems).
+  local update_test="${BUILD_DIR}/flatcar_test_update.gz"
+  delta_generator \
+      -private_key "/usr/share/update_engine/update-payload-key.key.pem" \
+      -new_image "${update_path}" \
+      -new_kernel "${BUILD_DIR}/${image_name%.bin}.vmlinuz" \
+      -out_file "${update_test}"
+
+  upload_image "${update_test}"
 }
 
 zip_update_tools() {

--- a/jenkins/kola/qemu.sh
+++ b/jenkins/kola/qemu.sh
@@ -50,6 +50,13 @@ if [[ "${KOLA_TESTS}" == "" ]]; then
   KOLA_TESTS="*"
 fi
 
+rm -f flatcar_test_update.gz
+bin/gangue get \
+    --json-key="${GOOGLE_APPLICATION_CREDENTIALS}" \
+    --verify=true $verify_key \
+    "${DOWNLOAD_ROOT}/boards/${BOARD}/${FLATCAR_VERSION}/flatcar_test_update.gz"
+mv flatcar_test_update.gz tmp/
+
 # Do not expand the kola test patterns globs
 set -o noglob
 enter sudo timeout --signal=SIGQUIT 12h kola run \
@@ -61,6 +68,7 @@ enter sudo timeout --signal=SIGQUIT 12h kola run \
     --qemu-image=/mnt/host/source/tmp/flatcar_production_image.bin \
     --tapfile="/mnt/host/source/${JOB_NAME##*/}.tap" \
     --torcx-manifest=/mnt/host/source/torcx_manifest.json \
+    --update-payload=/mnt/host/source/tmp/flatcar_test_update.gz \
     ${KOLA_TESTS}
 set +o noglob
 

--- a/jenkins/kola/qemu_uefi.sh
+++ b/jenkins/kola/qemu_uefi.sh
@@ -50,6 +50,13 @@ if [[ "${KOLA_TESTS}" == "" ]]; then
   KOLA_TESTS="*"
 fi
 
+rm -f flatcar_test_update.gz
+bin/gangue get \
+    --json-key="${GOOGLE_APPLICATION_CREDENTIALS}" \
+    --verify=true $verify_key \
+    "${DOWNLOAD_ROOT}/boards/${BOARD}/${FLATCAR_VERSION}/flatcar_test_update.gz"
+mv flatcar_test_update.gz tmp/
+
 # Do not expand the kola test patterns globs
 set -o noglob
 enter sudo timeout --signal=SIGQUIT 14h kola run \
@@ -61,6 +68,7 @@ enter sudo timeout --signal=SIGQUIT 14h kola run \
     --qemu-image=/mnt/host/source/tmp/flatcar_production_image.bin \
     --tapfile="/mnt/host/source/${JOB_NAME##*/}.tap" \
     --torcx-manifest=/mnt/host/source/torcx_manifest.json \
+    --update-payload=/mnt/host/source/tmp/flatcar_test_update.gz \
     ${KOLA_TESTS}
 set +o noglob
 


### PR DESCRIPTION
The kola update tests need a dev-key-signed update payload. This was
lacking and caused the update tests to be skipped.
Generate the test update payload for both dev builds and release builds
and run the kola tests for both. The test update payload has a special
name to not confuse it with the real update payload for releases, and
we keep the previous behavior to sign releases. Therefore, the
generate_update function wasn't used but the extract_update function
extended with generating the additional test payload.

## How to use

This replaces https://github.com/kinvolk/flatcar-scripts/pull/98

Depends on https://github.com/kinvolk/mantle/pull/187 and https://github.com/kinvolk/mantle/pull/189

In a follow-up PR I plan to add testing to update from the last release in addition.

*Note:* Should be picked for all channels.

## Testing done

http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3028/cldsv/
First the kola test failed because it did not find the `coreos-setgoodroot` command, this is fixed in https://github.com/kinvolk/mantle/pull/187 and then arm64 failed because the timeout was too strict, this is fixed in https://github.com/kinvolk/mantle/pull/189
Tested locally and by rerunning the Jenkins qemu jobs
