### PR TITLE
build_lib/qemu_tmpl: fix short-form warning

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -176,7 +176,7 @@ fi
 # ${CONFIG_DRIVE} or ${CONFIG_IMAGE} will be mounted in Flatcar as /media/configdrive
 if [ -n "${CONFIG_DRIVE}" ]; then
     set -- \
-        -fsdev local,id=conf,security_model=none,readonly,path="${CONFIG_DRIVE}" \
+        -fsdev local,id=conf,security_model=none,readonly=on,path="${CONFIG_DRIVE}" \
         -device virtio-9p-pci,fsdev=conf,mount_tag=config-2 "$@"
 fi
 
@@ -215,7 +215,7 @@ fi
 
 if [ -n "${VM_PFLASH_RO}" ] && [ -n "${VM_PFLASH_RW}" ]; then
     set -- \
-        -drive if=pflash,file="${SCRIPT_DIR}/${VM_PFLASH_RO}",format=raw,readonly \
+        -drive if=pflash,file="${SCRIPT_DIR}/${VM_PFLASH_RO}",format=raw,readonly=on \
         -drive if=pflash,file="${SCRIPT_DIR}/${VM_PFLASH_RW}",format=raw "$@"
 fi
 


### PR DESCRIPTION
starting from qemu-6.0.0, options with short-form are deprecated.

```
$ ./flatcar_production_qemu.sh
qemu-system-x86_64: -fsdev local,id=conf,security_model=none,readonly,path=/tmp/flatcar-configdrive.gyqmdrQqfA: warning: short-form boolean option 'readonly' deprecated
Please use readonly=on instead
```

See this commit: https://github.com/qemu/qemu/commit/ccd3b3b8112b670fdccf8a392b8419b173ffccb4

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

## Testing done

- tested with 
```
$ qlist -Ikv app-emulation/qemu
app-emulation/qemu-5.2.0-r2
app-emulation/qemu-6.0.0
```