### PR TITLE
disk_layout: devcontainer: use architecture agnostic part uuid

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -130,7 +130,7 @@
       "9":{
         "label":"ROOT",
         "fs_label":"ROOT",
-        "type":"4f68bce3-e8cd-4db1-96e7-fbcaf984b709",
+        "type":"0fc63daf-8483-4772-8e79-3d69d8477de4",
         "blocks":"12582912"
       }
     },


### PR DESCRIPTION
# disk_layout: devcontainer: use architecture agnostic part uuid

The previously used partition uuid for the rootfs partition of the devcontainer is x86 specific.
Change the partition uuid to one that works for both arches.

## How to use

```
./build_image --board=arm64-usr container
```

## Testing done

Ran the developer container on aarch64.
```
systemd-nspawn --image=flatcar_developer_container.bin
```