### PR TITLE
bootstrap_sdk: override seed path after building stage1

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -198,6 +198,7 @@ build_stage1() {
 if [[ "$STAGES" =~ stage1 ]]; then
     build_stage1
     STAGES="${STAGES/stage1/}"
+    SEED="${TYPE}/stage1-${ARCH}-latest"
 fi
 
 catalyst_build


### PR DESCRIPTION
# use built stage1 to build stage2

Logs show that currently the seed tarball is used for building stage1 and then stage2 - so the output of stage1 is discarded. This PR fixes that and uses stage1 results for stage2.

## How to use

`./bootstrap_sdk`

## Testing done

`./bootstrap_sdk`

Before:
```
26 Jul 2021 10:33:52 -00: NOTICE  : Emptying directory: /mnt/host/source/src/build/catalyst/tmp/flatcar-sdk/stage1-amd64-2021.07.26+dev-main-nightly-3124
26 Jul 2021 10:33:52 -00: NOTICE  : Starting auto from /mnt/host/source/src/build/catalyst/builds/seed/flatcar-sdk-amd64-2920.0.0.tar.bz2
26 Jul 2021 10:33:52 -00: NOTICE  : to /mnt/host/source/src/build/catalyst/tmp/flatcar-sdk/stage1-amd64-2021.07.26+dev-main-nightly-3124 (this may take some time) ..
...
26 Jul 2021 11:13:54 -00: NOTICE  : Emptying directory: /mnt/host/source/src/build/catalyst/tmp/flatcar-sdk/stage2-amd64-2021.07.26+dev-main-nightly-3124
26 Jul 2021 11:13:54 -00: NOTICE  : Starting auto from /mnt/host/source/src/build/catalyst/builds/seed/flatcar-sdk-amd64-2920.0.0.tar.bz2
26 Jul 2021 11:13:54 -00: NOTICE  : to /mnt/host/source/src/build/catalyst/tmp/flatcar-sdk/stage2-amd64-2021.07.26+dev-main-nightly-3124 (this may take some time) ..
```

After:
```
27 Jul 2021 09:28:41 -00: NOTICE  : Emptying directory: /mnt/host/source/src/build/catalyst/tmp/flatcar-sdk/stage1-amd64-2021.07.27+dev-flatcar-master-3136
27 Jul 2021 09:28:41 -00: NOTICE  : Starting auto from /mnt/host/source/src/build/catalyst/builds/seed/flatcar-sdk-amd64-2920.0.0.tar.bz2
27 Jul 2021 09:28:41 -00: NOTICE  : to /mnt/host/source/src/build/catalyst/tmp/flatcar-sdk/stage1-amd64-2021.07.27+dev-flatcar-master-3136 (this may take some time) ..
...
27 Jul 2021 10:10:40 -00: NOTICE  : Emptying directory: /mnt/host/source/src/build/catalyst/tmp/flatcar-sdk/stage2-amd64-2021.07.27+dev-flatcar-master-3136
27 Jul 2021 10:10:40 -00: NOTICE  : Starting auto from /mnt/host/source/src/build/catalyst/builds/flatcar-sdk/stage1-amd64-latest.tar.bz2
27 Jul 2021 10:10:40 -00: NOTICE  : to /mnt/host/source/src/build/catalyst/tmp/flatcar-sdk/stage2-amd64-2021.07.27+dev-flatcar-master-3136 (this may take some time) ..
```