### PR TITLE
build_image_util.sh: delete vmlinuz file from /usr partition

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -597,10 +597,13 @@ finish_image() {
     *) disable_read_write=${FLAGS_FALSE} ;;
   esac
 
-  # Copy kernel to support dm-verity boots
+  # Copy kernel to the /boot partition to support dm-verity boots by embedding
+  # the hash of the /usr partition into the kernel.
+  # Remove the kernel from the /usr partition to save space.
   sudo mkdir -p "${root_fs_dir}/boot/flatcar"
   sudo cp "${root_fs_dir}/usr/boot/vmlinuz" \
        "${root_fs_dir}/boot/flatcar/vmlinuz-a"
+  sudo rm "${root_fs_dir}/usr/boot/vmlinuz"*
 
   # Record directories installed to the state partition.
   # Explicitly ignore entries covered by existing configs.

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -661,7 +661,7 @@ _write_iso_disk() {
     pushd "${iso_target}" >/dev/null
     mkdir isolinux syslinux flatcar
     _write_cpio_common "$1" "${iso_target}/flatcar/cpio.gz"
-    cp "${base_dir}"/boot/vmlinuz "${iso_target}/flatcar/vmlinuz"
+    cp "${VM_TMP_ROOT}"/boot/flatcar/vmlinuz-a "${iso_target}/flatcar/vmlinuz"
     cp -R /usr/share/syslinux/* isolinux/
     cat<<EOF > isolinux/isolinux.cfg
 INCLUDE /syslinux/syslinux.cfg


### PR DESCRIPTION
The vmlinuz kernel image gets installed to /usr/boot/ but isn't usable
for dm-verity until it gets copied over to /boot/flatcar/ and the hash
gets embedded at a particular offset. The file in /usr/boot/ uses space
while it's not having a real purpose as long as dm-verity is used.

Delete the vmlinuz file under /usr/boot/ to free up space.

## How to use

Build an image and run all tests

→ 203 MB free on `/usr`

## Testing done

http://localhost:9091/job/os/job/manifest/3150/cldsv/