### PR TITLE
Revert "disk_layout: use btrfs for the OEM partition"

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -51,8 +51,7 @@
         "fs_label":"OEM",
         "type":"data",
         "blocks":"262144",
-        "fs_type":"btrfs",
-        "fs_compression":"zlib",
+        "fs_type":"ext4",
         "mount":"/usr/share/oem"
       },
       "7":{


### PR DESCRIPTION
Until https://github.com/kinvolk/Flatcar/issues/461 is resolved we should not switch the OEM partition to compression with btrfs yet.
Also see https://github.com/kinvolk/ignition/pull/22

This reverts commit bc97e15c3cd55f10cc11016578673744e3220ffc.

