### PR TITLE
Revert "Revert "disk_layout: use btrfs for the OEM partition""

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -51,7 +51,8 @@
         "fs_label":"OEM",
         "type":"data",
         "blocks":"262144",
-        "fs_type":"ext4",
+        "fs_type":"btrfs",
+        "fs_compression":"zlib",
         "mount":"/usr/share/oem"
       },
       "7":{


### PR DESCRIPTION
This reverts commit bb9ddfb08a83a456fc56962e62538bdfc0031a2f,
meaning that the planned change is now done and we switch the OEM
partition to btrfs. The reason for the revert is resolved in
https://github.com/kinvolk/ignition/pull/22

## How to use


## Testing done

In the mentioned PR is was tested that there is no regression when using btrfs for the OEM partition with an existing Ignition config which refers to the OEM partition with ext4