### PR TITLE
bootstrap_sdk: skip uploading non-existent directory to fix Rust builds

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -233,9 +233,11 @@ if [[ "$STAGES" =~ stage4 ]]; then
     sign_and_upload_files "packages" "${def_upload_path}" "pkgs/" \
         "${BINPKGS}"/*
 
-    # Upload the SDK toolchain packages
-    sign_and_upload_files "cross toolchain packages" "${def_upload_path}" \
-        "toolchain/" "${BINPKGS}/crossdev"/*
+    if [ -d "${BINPKGS}/crossdev" ]; then
+        # Upload the SDK toolchain packages
+        sign_and_upload_files "cross toolchain packages" "${def_upload_path}" \
+            "toolchain/" "${BINPKGS}/crossdev"/*
+    fi
 fi
 
 command_completed


### PR DESCRIPTION
Previously before https://github.com/kinvolk/flatcar-scripts/pull/134, `bootstrap_sdk` was looking at the wrong path (`/usr/lib/rust-*/rustlib/aarch64-unknown-linux-gnu` instead of
`/usr/lib/rustlib/aarch64-unknown-linux-gnu`).
As a result, Rust got always removed and rebuilt in `install_cross_rust`, which resulted in `flatcar-sdk/crossdev/dev-lang/rust/rust-1.54.0-1.xpak` being created.

Now legitimate changes of https://github.com/kinvolk/flatcar-scripts/pull/134 prevent the rebuild from happening.
The path already exists in a stage4 SDK build, because the seed stage already has cross-compilers so the Rust upgrade has all the right cross-paths.

That's why SDK builds with only stage4 failed when it tries uploading Rust packages like the following.
On the other hand, full SDK builds with stage1 to 4 worked well, because in that case Rust is rebuilt anyway.

```
INFO    bootstrap_sdk: Uploading cross toolchain packages to gs://flatcar-jenkins/developer/sdk/amd64/2021.08.04+dev-flatcar-master-3209
CommandException: No URLs matched: /mnt/host/source/src/build/catalyst/packages/flatcar-sdk/crossdev/*
CommandException: No URLs matched: /tmp/tmp.xyjXbCFhUc//mnt/host/source/src/build/catalyst/packages/flatcar-sdk/crossdev/*.sig
CommandException: 2 files/objects could not be transferred.
```

To fix that, we have to skip uploading packages when the crossdev directory does not exist.

Debugged and suggested by @jepio .

## Testing done

CI passed (only stage4): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3238/cldsv (v1)
CI passed (stage1-4): http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3244/cldsv (v2)