### PR TITLE
build_library: support multi-arch in generate_au_zip

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -83,7 +83,7 @@ zip_update_tools() {
   # Make sure some vars this script needs are exported
   export REPO_MANIFESTS_DIR SCRIPTS_DIR
   "${BUILD_LIBRARY_DIR}/generate_au_zip.py" \
-    --output-dir "${BUILD_DIR}" --zip-name "${update_zip}"
+    --arch "$(get_sdk_arch)" --output-dir "${BUILD_DIR}" --zip-name "${update_zip}"
 
   upload_image "${BUILD_DIR}/${update_zip}"
 }

--- a/build_library/generate_au_zip.py
+++ b/build_library/generate_au_zip.py
@@ -105,7 +105,7 @@ def DepsToCopy(ldd_files, allow_list):
   """Returns a list of deps for a given dynamic executables list.
     Args:
       ldd_files: List of dynamic files that needs to have the deps evaluated
-      deny_list: List of files that we should ignore
+      allow_list: List of files that we should allow
    Returns:
      List of files that are dependencies
   """
@@ -146,6 +146,7 @@ def CopyRequiredFiles(dest_files_root, allow_list):
   """Generates a list of files that are required for au-generator zip file
     Args:
       dest_files_root: location of the directory where we should copy the files
+      allow_list: List of files that we should allow
   """
   if not dest_files_root:
     logging.error('Invalid option passed for dest_files_root')
@@ -286,12 +287,10 @@ def _ExcludeDenylist(library_list, deny_list=[]):
 
 
 def _EnforceAllowList(library_list, allow_list=[]):
-  """Deletes the set of files from deny_list from the library_list
+  """Ensures that library_list contains all the items from allow_list
     Args:
-      library_list: List of the library names to filter through deny_list
-      deny_list: List of the deny listed names to filter
-    Returns:
-      Filtered library_list
+      library_list: List of the library names to check
+      allow_list: List of the items that ought to be in the library_list
   """
 
   for allow_item in allow_list:


### PR DESCRIPTION
To be able to support arm64 native SDK without cross builds, we should make `generate_au_zip` support both architectures, amd64 and arm64.

Without doing that, `build_image` fails with `ERROR : Required WHITE_LIST items ld-linux-x86-64.so.2 not found!!!`, because the script recognizes only amd64 libs in WHITE_LIST.

We should first determine the architecture in build_image, before running `generate_au_zip`, and pass the architecture, either amd64 or arm64.
Also add `allow_list` and `ld_linux` parameters to necessary functions.
Replace `black list` with `deny list`, `white list` with `allow list`.

## How to use

```
...
./build_image
```

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3281/cldsv