### PR TITLE
*: Use the internal copy of cros_workon

### DIFF
--- a/build_packages
+++ b/build_packages
@@ -166,7 +166,7 @@ fi
 # Build cros_workon packages when they are changed.
 CROS_WORKON_PKGS=()
 if [ "${FLAGS_workon}" -eq "${FLAGS_TRUE}" ]; then
-  CROS_WORKON_PKGS+=( $(cros_workon list --board=${FLAGS_board}) )
+  CROS_WORKON_PKGS+=( $("${SRC_ROOT}/scripts/cros_workon" list --board=${FLAGS_board}) )
 fi
 
 if [[ ${#CROS_WORKON_PKGS[@]} -gt 0 ]]; then

--- a/setup_board
+++ b/setup_board
@@ -98,7 +98,7 @@ generate_all_wrappers() {
   wrapper="/usr/local/bin/cros_workon-${BOARD_VARIANT}"
   sudo_clobber "${wrapper}" <<EOF
 #!/bin/bash
-exec cros_workon --board ${BOARD_VARIANT} "\$@"
+exec "${SRC_ROOT}/scripts/cros_workon" --board ${BOARD_VARIANT} "\$@"
 EOF
   wrappers+=( "${wrapper}" )
 
@@ -346,7 +346,7 @@ info "The SYSROOT is: ${BOARD_ROOT}"
 # NOTE: Printing the working-on ebuilds does not only serve the informative
 # purpose. It also causes the ${BOARD_ROOT}/etc/portage/package.* files to be
 # regenerated.
-WORKING_ON=$(cros_workon --board=${FLAGS_board} list)
+WORKING_ON=$("${SRC_ROOT}/scripts/cros_workon" --board=${FLAGS_board} list)
 if [ -n "${WORKING_ON}" ]; then
   info
   info "Currently working on the following ebuilds for this board:"

--- a/update_chroot
+++ b/update_chroot
@@ -231,7 +231,7 @@ fi
 
 # Build cros_workon packages when they are changed.
 if [ "${FLAGS_workon}" -eq "${FLAGS_TRUE}" ]; then
-  for pkg in $(cros_workon list --host); do
+  for pkg in $("${SRC_ROOT}/scripts/cros_workon" list --host); do
     EMERGE_FLAGS+=( "--reinstall-atoms=${pkg}" "--usepkg-exclude=${pkg}" )
   done
 fi


### PR DESCRIPTION
The scripts that invoked `cros_workon` without specifying a path to
the script were not calling the internal `cros_workon` directly, but
rather a copy installed in `/usr/bin/cros_workon`.
`/usr/bin/cros_workon` comes from the `coreos-base/cros-devutil` and
is a wrapper script that sources `common.sh` file to figure the
location of the `scripts` and finally invokes the internal
`cros_workon`. Curious thing is that the sourced `common.sh` comes
from the `/usr/lib/crosutils` directory and contents of the directory
come from the `dev-util/crosutils` package. And that `common.sh` is
different from the one in the scripts directory, but fortunately the
part that detects the path to the `scripts` directory is the same. I'm
not sure where where exactly the copy of `common.sh` in
`/usr/lib/crosutils` comes from - likely from somewhere in
`https://chromium.googlesource.com/chromiumos/platform/crosutils`.

Just cut the middle layers and call the internal copy of `cros_workon`
directly.

CI: http://localhost:9091/job/os/job/manifest/3332/cldsv/
