### PR TITLE
build_library/disk_util: use byte array for conversion, not chr()

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -711,9 +711,9 @@ def Tune2fsReadWrite(options, partition, disable_rw):
   # offset of ro_compat, highest order byte (le 32 bit field)
   flag_offset = 0x464 + 3
   flag_value = 0xff if disable_rw else 0x00
-  with open(options.disk_image, 'r+') as image:
+  with open(options.disk_image, 'br+') as image:
     image.seek(partition['first_byte'] + flag_offset)
-    image.write(chr(flag_value))
+    image.write(bytes([flag_value]))
 
 
 def IsE2fsReadWrite(options, partition):


### PR DESCRIPTION
disk_util sometimes bails out during build with an ASCII conversion error:

```
Traceback (most recent call last):
  File "/mnt/host/source/src/scripts/build_library/disk_util", line 1114, in <module>
    main(sys.argv)
  File "/mnt/host/source/src/scripts/build_library/disk_util", line 1110, in main
    options.func(options)
  File "/mnt/host/source/src/scripts/build_library/disk_util", line 779, in Verity
    Tune2fsReadWrite(options, part, disable_rw=True)
  File "/mnt/host/source/src/scripts/build_library/disk_util", line 716, in Tune2fsReadWrite
    image.write(chr(flag_value))
UnicodeEncodeError: 'ascii' codec can't encode character '\xff' in position 0: ordinal not in range(128)
```
Curiously, the error does not reproduce every time (though the code leading to the error is straightforward), hinting at terminal settings playing a role.

This change converts the integer to be written to a byte array (of size 1) instead of using chr(). Also, the file to be written is explicitly opened in binary mode.

## How to use / testing done
- build flatcar image
- launch in qemu
- verify r/o is still in place
  ```
  $ sudo touch /urs/test-ro
  touch: cannot touch /urs/test-ro: Read-only file system
  ```