### PR TITLE
jenkins: add script to run kola arm64 tests under docker

### DIFF
--- a/jenkins/kola/Dockerfile.kola-test-runner
+++ b/jenkins/kola/Dockerfile.kola-test-runner
@@ -1,0 +1,4 @@
+FROM debian:11
+
+RUN apt-get update && \
+  apt-get install -y qemu-system-aarch64 qemu-efi-aarch64 lbzip2 sudo dnsmasq gnupg2 git curl iptables

--- a/jenkins/kola/qemu_uefi.sh
+++ b/jenkins/kola/qemu_uefi.sh
@@ -2,4 +2,8 @@
 set -ex
 
 SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
-"${SCRIPTFOLDER}/qemu_common.sh" qemu_uefi
+if [[ "$NATIVE_ARM64" == true ]]; then
+  "${SCRIPTFOLDER}/qemu_uefi_arm64.sh" qemu_uefi
+else
+  "${SCRIPTFOLDER}/qemu_common.sh" qemu_uefi
+fi

--- a/jenkins/kola/qemu_uefi_arm64.sh
+++ b/jenkins/kola/qemu_uefi_arm64.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -ex
+
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+# strip $PWD prefix so that we can access the path relative to the container working directory
+SCRIPTFOLDER=${SCRIPTFOLDER#$PWD/}
+
+DOCKER_IMG=ghcr.io/kinvolk/kola-test-runner:latest
+
+envarg=()
+envflags=(
+  SSH_AUTH_SOCK
+  BOARD
+  MANIFEST_URL
+  SDK_URL_PATH
+  CHANNEL_BASE
+  GROUP
+  KOLA_TESTS
+  MANIFEST_TAG
+  DOWNLOAD_ROOT
+  PARALLEL
+  GOOGLE_APPLICATION_CREDENTIALS
+  NATIVE_ARM64
+)
+for envvar in ${envflags[@]}; do
+  envarg+=( -e "${envvar}=${!envvar}" )
+done
+
+docker pull ${DOCKER_IMG}
+exec docker run --privileged \
+  --rm \
+  -v /dev:/dev \
+  -w /mnt/host/source \
+  -v ${PWD}:/mnt/host/source \
+  -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS} \
+  ${SSH_AUTH_SOCK:+-v ${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}} \
+  "${envarg[@]}" \
+  ${DOCKER_IMG} \
+  "${SCRIPTFOLDER}/qemu_common.sh" qemu_uefi


### PR DESCRIPTION
# jenkins: add script to run kola arm64 tests under docker

This PR introduces a script that runs qemu_uefi arm64 tests through a docker container instead of in a Flatcar SDK. The entrypoint uses the jenins paramter 'NATIVE_ARM64' to select whether to use the normal path, or the docker path.