### PR TITLE
build_library: update allow list for GLSA checks 2021-09-03

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -8,6 +8,14 @@ GLSA_WHITELIST=(
 	201909-01 # Perl, SDK only
 	202003-26 # SDK only
 	202005-09 # SDK only
+	202006-03 # perl, SDK only
+	202008-01 # python, SDK only
+	202101-18 # python, SDK only
+	202104-04 # python, SDK only
+	202105-22 # samba, not affected, samba has no ldap flag, no smbd.
+	202105-34 # bash, non-trivial
+	202107-31 # polkit, in-progress
+	202107-48 # systemd, backported fixes to v247.
 )
 
 glsa_image() {

--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -5,20 +5,8 @@
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
 	201908-14 # backported both CVE fixes
-	201904-13 # git
 	201909-01 # Perl, SDK only
-	201909-08 # backported fix
-	201911-01 # package too old to even have the affected USE flag
-	202003-20 # backported fix
-	202003-12 # only applies to old, already-fixed CVEs
-	202003-24 # SDK only
 	202003-26 # SDK only
-	202003-30 # fixed by updating within older minor release
-	202003-31 # SDK only
-	202003-52 # difficult to update :-(
-	202004-10 # fixed by updating within older minor release
-	202004-13 # fixed by updating within older minor release
-	202005-02 # SDK only
 	202005-09 # SDK only
 )
 


### PR DESCRIPTION
Clean up following entries from the GLSA allow list.

* 201904-13: git 2.26.3, so not affected
* 201909-08: dbus 1.12.20, so not affected
* 201911-01: openssh 8.6, so not affected
* 202003-12: sudo 1.9.5, so not affected
* 202003-20: systemd 246+, so not affected
* 202003-24: file 5.39, so not affected
* 202003-30: git 2.26.3, so not affected
* 202003-31: gdb 9.2, so not affected
* 202003-52: samba 4.12.9, so not affected
* 202004-10: openssl 1.1.1l, so not affected
* 202004-13: git 2.26.3, so not affected
* 202005-02: qemu 5.2, so not affected

Add the following entries to the GLSA allow list.

* 202006-03: perl 5.26.2, only SDK, allowlist
* 202008-01: python 2.7.15 & 3.6.5, only SDK, allowlist
* 202101-18: python 2.7.15 & 3.6.5, only SDK, allowlist
* 202104-04: python 2.7.15 & 3.6.5, only SDK, allowlist
* 202105-22: samba 4.12.9, not affected, samba has no ldap flag, no smbd.
* 202105-34: bash 4.3, non-trivial to update
* 202107-31: polkit 0.113, in-progress
* 202107-48: systemd 247.9, backported the fixes to v247.9.

This PR should be merged together with https://github.com/kinvolk/portage-stable/pull/210.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3509/cldsv